### PR TITLE
test(gcp): add unit and integration test suite for MCP Gateway tools and API

### DIFF
--- a/docs/validation.md
+++ b/docs/validation.md
@@ -85,6 +85,7 @@ python3 -m py_compile src/*.py
 # GCP Cloud Run MCP Gateway
 cd services/gcp/mcpGateway
 python3 -m py_compile main.py auth.py tools/*.py
+pytest
 ```
 
 ---

--- a/services/gcp/mcpGateway/requirements.txt
+++ b/services/gcp/mcpGateway/requirements.txt
@@ -6,3 +6,6 @@ httpx>=0.26.0
 beautifulsoup4>=4.12.0
 google-cloud-storage>=2.14.0
 pydantic>=2.6.0
+requests>=2.31.0
+pytest>=7.4.0
+pytest-asyncio>=0.23.0

--- a/services/gcp/mcpGateway/tests/__init__.py
+++ b/services/gcp/mcpGateway/tests/__init__.py
@@ -1,0 +1,1 @@
+# Tests Package for GCP Cloud Run MCP Gateway

--- a/services/gcp/mcpGateway/tests/test_gateway_api.py
+++ b/services/gcp/mcpGateway/tests/test_gateway_api.py
@@ -1,0 +1,102 @@
+import os
+import pytest
+from unittest.mock import patch
+from fastapi.testclient import TestClient
+from main import app
+
+client = TestClient(app)
+
+def test_health_check():
+    response = client.get("/health")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "ok"
+    assert data["tools_count"] == 3
+
+
+def test_auth_verify_unauthorized():
+    with patch.dict(os.environ, {"DISABLE_AUTH": "false"}):
+        response = client.get("/api/auth/verify")
+        assert response.status_code == 401
+        assert "Missing Authorization bearer token" in response.json()["detail"]
+
+
+def test_auth_verify_disabled_auth():
+    with patch("auth.DISABLE_AUTH", True):
+        response = client.get("/api/auth/verify")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "authenticated"
+        assert data["user"]["email"] == "dev-user@example.com"
+
+
+def test_list_tools_api():
+    with patch("auth.DISABLE_AUTH", True):
+        response = client.get("/api/tools")
+        assert response.status_code == 200
+        tools = response.json()["tools"]
+        tool_names = [t["name"] for t in tools]
+        assert "fetch_web_page" in tool_names
+        assert "store_memory" in tool_names
+        assert "query_memory" in tool_names
+
+
+def test_call_tool_api_store_and_query():
+    with patch("auth.DISABLE_AUTH", True):
+        # 1. Call store_memory
+        store_res = client.post(
+            "/api/tools/call",
+            json={
+                "name": "store_memory",
+                "arguments": {
+                    "name": "Pytest Tool",
+                    "category": "Testing",
+                    "observation": "Verified via TestClient"
+                }
+            }
+        )
+        assert store_res.status_code == 200
+        assert store_res.json()["success"] is True
+        assert "Pytest Tool" in store_res.json()["result"]
+
+        # 2. Call query_memory
+        query_res = client.post(
+            "/api/tools/call",
+            json={
+                "name": "query_memory",
+                "arguments": {"query": "Pytest Tool"}
+            }
+        )
+        assert query_res.status_code == 200
+        assert query_res.json()["success"] is True
+        assert "Pytest Tool" in query_res.json()["result"]
+
+
+def test_mcp_jsonrpc_initialize():
+    # Setup session
+    from main import sse_sessions
+    import asyncio
+    
+    session_id = "test-session-123"
+    queue = asyncio.Queue()
+    sse_sessions[session_id] = queue
+
+    try:
+        response = client.post(
+            f"/messages?session_id={session_id}",
+            json={
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "initialize",
+                "params": {}
+            }
+        )
+        assert response.status_code == 200
+        assert response.json()["status"] == "accepted"
+        
+        # Check queued response
+        res_msg = queue.get_nowait()
+        assert res_msg["id"] == 1
+        assert res_msg["result"]["protocolVersion"] == "2024-11-05"
+    finally:
+        sse_sessions.pop(session_id, None)

--- a/services/gcp/mcpGateway/tests/test_memory.py
+++ b/services/gcp/mcpGateway/tests/test_memory.py
@@ -1,0 +1,63 @@
+import os
+import pytest
+from tools.memory import remember_entity, recall_entities, LOCAL_MEMORY_FILE
+
+@pytest.fixture(autouse=True)
+def cleanup_local_memory():
+    """Ensure temporary memory file is cleaned up before and after tests."""
+    if os.path.exists(LOCAL_MEMORY_FILE):
+        os.remove(LOCAL_MEMORY_FILE)
+    yield
+    if os.path.exists(LOCAL_MEMORY_FILE):
+        os.remove(LOCAL_MEMORY_FILE)
+
+@pytest.mark.asyncio
+async def test_remember_entity():
+    res = await remember_entity(
+        name="Cloud Run",
+        category="GCP Compute",
+        observations=["Serverless container execution platform.", "Scales to zero."]
+    )
+    
+    assert res["status"] in ["success", "warning_local_only"]
+    assert res["entity"]["name"] == "Cloud Run"
+    assert res["entity"]["category"] == "GCP Compute"
+    assert len(res["entity"]["observations"]) == 2
+
+
+@pytest.mark.asyncio
+async def test_remember_entity_append():
+    await remember_entity(
+        name="GCP Cloud Run",
+        category="Compute",
+        observations=["Supports WebSockets and SSE."]
+    )
+    
+    res = await remember_entity(
+        name="GCP Cloud Run",
+        category="Compute",
+        observations=["Supports WebSockets and SSE.", "Pay per request billing."]
+    )
+    
+    # Check deduplication
+    assert len(res["entity"]["observations"]) == 2
+    assert "Pay per request billing." in res["entity"]["observations"]
+
+
+@pytest.mark.asyncio
+async def test_recall_entities_query():
+    await remember_entity("FastAPI", "Framework", ["High performance Python web framework."])
+    await remember_entity("Cloud Run", "Compute", ["Google Cloud serverless hosting."])
+
+    # Recall all
+    all_res = await recall_entities()
+    assert all_res["total_count"] == 2
+
+    # Query filter match
+    fastapi_res = await recall_entities(query="FastAPI")
+    assert fastapi_res["matches"] == 1
+    assert "FastAPI" in fastapi_res["entities"]
+
+    # Query filter non-match
+    none_res = await recall_entities(query="NonExistent")
+    assert none_res["matches"] == 0

--- a/services/gcp/mcpGateway/tests/test_web_fetch.py
+++ b/services/gcp/mcpGateway/tests/test_web_fetch.py
@@ -1,0 +1,59 @@
+import pytest
+from unittest.mock import patch, MagicMock
+from tools.web_fetch import fetch_web_markdown
+
+@pytest.mark.asyncio
+async def test_fetch_web_markdown_success():
+    sample_html = """
+    <!DOCTYPE html>
+    <html>
+      <head><title>Test MCP Page</title></head>
+      <body>
+        <nav>Navigation Menu</nav>
+        <h1>Welcome to MCP Gateway</h1>
+        <p>This is a high-speed HTML to Markdown converter.</p>
+        <script>console.log("ignore me");</script>
+      </body>
+    </html>
+    """
+    
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.text = sample_html
+    mock_response.raise_for_status = MagicMock()
+
+    with patch("httpx.AsyncClient.get", return_value=mock_response):
+        result = await fetch_web_markdown("https://example.com/test", max_chars=500)
+
+    assert result["status_code"] == 200
+    assert result["title"] == "Test MCP Page"
+    assert "Welcome to MCP Gateway" in result["markdown"]
+    assert "Navigation Menu" not in result["markdown"]  # Nav tag stripped
+    assert "console.log" not in result["markdown"]     # Script tag stripped
+    assert result["truncated"] is False
+
+
+@pytest.mark.asyncio
+async def test_fetch_web_markdown_truncation():
+    sample_html = "<html><head><title>Long Page</title></head><body>" + "<p>Word </p>" * 100 + "</body></html>"
+    
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.text = sample_html
+    mock_response.raise_for_status = MagicMock()
+
+    with patch("httpx.AsyncClient.get", return_value=mock_response):
+        result = await fetch_web_markdown("https://example.com/long", max_chars=50)
+
+    assert result["truncated"] is True
+    assert "...[Truncated due to length]" in result["markdown"]
+
+
+@pytest.mark.asyncio
+async def test_fetch_web_markdown_error_handling():
+    with patch("httpx.AsyncClient.get", side_effect=Exception("Connection refused")):
+        result = await fetch_web_markdown("https://invalid-domain-does-not-exist.com")
+
+    assert result["status"] == "failed"
+    assert "error" in result
+    assert "Connection refused" in result["error"]


### PR DESCRIPTION
## Summary
- Added 12 comprehensive pytest unit and integration test cases in `services/gcp/mcpGateway/tests/`.
- Tests `fetch_web_page` HTML-to-Markdown scraper, title extraction, nav/script stripping, and error handling (`test_web_fetch.py`).
- Tests `store_memory` and `query_memory` knowledge graph entity persistence and observation deduplication (`test_memory.py`).
- Tests FastAPI health check, OAuth 2.0 unauthorized 401 guard, tool listing, REST tool execution, and MCP JSON-RPC 2.0 protocol over SSE (`test_gateway_api.py`).