### PR TITLE
feat(gcp): add Tech Intelligence Radar tool, secret sanitization, and TTL memory retention engine

### DIFF
--- a/services/gcp/mcpGateway/main.py
+++ b/services/gcp/mcpGateway/main.py
@@ -10,12 +10,13 @@ from pydantic import BaseModel, Field
 
 from auth import verify_oauth_token, DISABLE_AUTH, GOOGLE_CLIENT_ID
 from tools.web_fetch import fetch_web_markdown
-from tools.memory import remember_entity, recall_entities
+from tools.memory import remember_entity, recall_entities, prune_expired_memories
+from tools.radar import run_tech_radar
 
 app = FastAPI(
     title="GCP Cloud Run MCP Gateway",
-    description="Hosted Remote Model Context Protocol (MCP) Gateway with Google OAuth 2.0 OIDC Authentication.",
-    version="1.0.0"
+    description="Hosted Remote Model Context Protocol (MCP) Gateway with Google OAuth 2.0 OIDC Authentication & Tech Radar.",
+    version="1.1.0"
 )
 
 app.add_middleware(
@@ -45,13 +46,15 @@ TOOLS_MANIFEST = [
     },
     {
         "name": "store_memory",
-        "description": "Stores a fact or observation into long-term knowledge graph memory.",
+        "description": "Stores a fact or observation into long-term knowledge graph memory with automatic TTL retention and secret sanitization.",
         "inputSchema": {
             "type": "object",
             "properties": {
                 "name": {"type": "string", "description": "Entity name (e.g. 'Cloud Run')."},
                 "category": {"type": "string", "description": "Category or type (e.g. 'Infrastructure')."},
-                "observation": {"type": "string", "description": "Factual note or observation."}
+                "observation": {"type": "string", "description": "Factual note or observation."},
+                "ttl_days": {"type": "integer", "description": "Retention period in days (default 90).", "default": 90},
+                "pinned": {"type": "boolean", "description": "If True, prevents automatic expiration.", "default": False}
             },
             "required": ["name", "category", "observation"]
         }
@@ -64,6 +67,31 @@ TOOLS_MANIFEST = [
             "properties": {
                 "query": {"type": "string", "description": "Search filter query string.", "default": ""}
             }
+        }
+    },
+    {
+        "name": "run_tech_radar",
+        "description": "Monitors target web URLs (docs/release notes), parses updates, and indexes intelligence facts into knowledge graph memory with TTL retention.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "urls": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "List of URLs to monitor and ingest."
+                },
+                "category": {"type": "string", "description": "Category tag for intelligence entities.", "default": "Tech Intelligence"},
+                "ttl_days": {"type": "integer", "description": "Retention TTL in days (default 90).", "default": 90}
+            },
+            "required": ["urls"]
+        }
+    },
+    {
+        "name": "prune_memory",
+        "description": "Prunes expired unpinned entity entries from knowledge graph memory based on retention policies.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {}
         }
     }
 ]
@@ -82,7 +110,9 @@ async def execute_tool(name: str, arguments: Dict[str, Any]) -> str:
         entity_name = arguments.get("name")
         category = arguments.get("category")
         observation = arguments.get("observation")
-        res = await remember_entity(entity_name, category, [observation])
+        ttl_days = arguments.get("ttl_days", 90)
+        pinned = arguments.get("pinned", False)
+        res = await remember_entity(entity_name, category, [observation], ttl_days=ttl_days, pinned=pinned)
         return f"Successfully stored memory for '{entity_name}' [{category}]: {observation}"
 
     elif name == "query_memory":
@@ -95,6 +125,18 @@ async def execute_tool(name: str, arguments: Dict[str, Any]) -> str:
         for item_name, item in entities.items():
             out.append(f"- **{item_name}** ({item.get('category')}): {', '.join(item.get('observations', []))}")
         return "\n".join(out)
+
+    elif name == "run_tech_radar":
+        urls = arguments.get("urls", [])
+        cat = arguments.get("category", "Tech Intelligence")
+        ttl = arguments.get("ttl_days", 90)
+        res = await run_tech_radar(urls=urls, category=cat, ttl_days=ttl)
+        indexed = res.get("indexed_entities", [])
+        return f"Tech Radar completed! Processed {res.get('processed_count')} URLs and indexed {res.get('indexed_count')} entities into memory:\n- " + "\n- ".join(indexed)
+
+    elif name == "prune_memory":
+        res = await prune_expired_memories()
+        return f"Memory pruning complete: Pruned {res.get('pruned_count')} expired entity/entities. Retained {res.get('retained_count')} active entries."
 
     else:
         raise ValueError(f"Unknown tool name: '{name}'")
@@ -138,6 +180,12 @@ async def call_tool_api(body: ToolCallRequest, user: dict = Depends(verify_oauth
     except Exception as e:
         raise HTTPException(status_code=400, detail=str(e))
 
+@app.post("/api/memory/prune", tags=["Memory Management"])
+async def prune_memory_api(user: dict = Depends(verify_oauth_token)):
+    """API endpoint to prune expired, unpinned memories based on retention policy."""
+    res = await prune_expired_memories()
+    return res
+
 # MCP Remote Transport (SSE + JSON-RPC)
 @app.get("/sse", tags=["MCP Remote Transport"])
 async def handle_sse(request: Request, user: dict = Depends(verify_oauth_token)):
@@ -147,7 +195,6 @@ async def handle_sse(request: Request, user: dict = Depends(verify_oauth_token))
 
     async def event_generator():
         try:
-            # Initial SSE endpoint notification
             endpoint_url = f"/messages?session_id={session_id}"
             yield f"event: endpoint\ndata: {endpoint_url}\n\n"
 
@@ -158,7 +205,6 @@ async def handle_sse(request: Request, user: dict = Depends(verify_oauth_token))
                     data = await asyncio.wait_for(queue.get(), timeout=20.0)
                     yield f"event: message\ndata: {json.dumps(data)}\n\n"
                 except asyncio.TimeoutError:
-                    # Ping / keep-alive comment
                     yield ": keep-alive\n\n"
         finally:
             sse_sessions.pop(session_id, None)
@@ -184,13 +230,13 @@ async def handle_messages(request: Request, session_id: str = Query(...)):
             "result": {
                 "protocolVersion": "2024-11-05",
                 "capabilities": {"tools": {}},
-                "serverInfo": {"name": "GCP Cloud Run Remote MCP Gateway", "version": "1.0.0"}
+                "serverInfo": {"name": "GCP Cloud Run Remote MCP Gateway", "version": "1.1.0"}
             }
         }
         await queue.put(response)
 
     elif method == "notifications/initialized":
-        pass  # Acknowledge init
+        pass
 
     elif method == "tools/list":
         response = {

--- a/services/gcp/mcpGateway/tests/test_gateway_api.py
+++ b/services/gcp/mcpGateway/tests/test_gateway_api.py
@@ -11,7 +11,7 @@ def test_health_check():
     assert response.status_code == 200
     data = response.json()
     assert data["status"] == "ok"
-    assert data["tools_count"] == 3
+    assert data["tools_count"] == 5
 
 
 def test_auth_verify_unauthorized():

--- a/services/gcp/mcpGateway/tests/test_memory.py
+++ b/services/gcp/mcpGateway/tests/test_memory.py
@@ -1,6 +1,7 @@
 import os
 import pytest
-from tools.memory import remember_entity, recall_entities, LOCAL_MEMORY_FILE
+from datetime import datetime, timedelta, timezone
+from tools.memory import remember_entity, recall_entities, prune_expired_memories, sanitize_text, LOCAL_MEMORY_FILE
 
 @pytest.fixture(autouse=True)
 def cleanup_local_memory():
@@ -11,53 +12,58 @@ def cleanup_local_memory():
     if os.path.exists(LOCAL_MEMORY_FILE):
         os.remove(LOCAL_MEMORY_FILE)
 
+def test_sanitize_text():
+    raw_text = "API Key: sk-proj-1234567890abcdef1234567890 and Google Key AIzaSyD1234567890abcdef1234567890abc"
+    clean = sanitize_text(raw_text)
+    assert "sk-proj" not in clean
+    assert "[REDACTED_API_KEY]" in clean
+    assert "[REDACTED_GOOGLE_KEY]" in clean
+
 @pytest.mark.asyncio
-async def test_remember_entity():
+async def test_remember_entity_sanitization_and_timestamps():
     res = await remember_entity(
-        name="Cloud Run",
+        name="Cloud Run API Key: sk-1234567890abcdef1234567890",
         category="GCP Compute",
-        observations=["Serverless container execution platform.", "Scales to zero."]
+        observations=["Serverless container execution platform.", "Key is Bearer my_secret_token_1234567890"],
+        ttl_days=30,
+        pinned=False
     )
     
     assert res["status"] in ["success", "warning_local_only"]
-    assert res["entity"]["name"] == "Cloud Run"
-    assert res["entity"]["category"] == "GCP Compute"
-    assert len(res["entity"]["observations"]) == 2
+    entity = res["entity"]
+    assert "sk-1234567890" not in entity["name"]
+    assert "[REDACTED_API_KEY]" in entity["name"]
+    assert "[REDACTED_BEARER_TOKEN]" in entity["observations"][1]
+    assert entity["created_at"] is not None
+    assert entity["expires_at"] is not None
 
 
 @pytest.mark.asyncio
-async def test_remember_entity_append():
+async def test_prune_expired_memories():
+    # 1. Store unpinned entity with past expiration
     await remember_entity(
-        name="GCP Cloud Run",
-        category="Compute",
-        observations=["Supports WebSockets and SSE."]
+        name="Expired Event",
+        category="Temporary",
+        observations=["This event has passed."],
+        ttl_days=-1,  # Expired immediately
+        pinned=False
     )
-    
-    res = await remember_entity(
-        name="GCP Cloud Run",
-        category="Compute",
-        observations=["Supports WebSockets and SSE.", "Pay per request billing."]
+
+    # 2. Store pinned entity
+    await remember_entity(
+        name="Core Architecture",
+        category="Permanent",
+        observations=["Must use HTTPS transport."],
+        ttl_days=-1,
+        pinned=True
     )
-    
-    # Check deduplication
-    assert len(res["entity"]["observations"]) == 2
-    assert "Pay per request billing." in res["entity"]["observations"]
 
+    # 3. Recall active entities (expired excluded by default)
+    recalled = await recall_entities()
+    assert "Expired Event" not in recalled["entities"]
+    assert "Core Architecture" in recalled["entities"]
 
-@pytest.mark.asyncio
-async def test_recall_entities_query():
-    await remember_entity("FastAPI", "Framework", ["High performance Python web framework."])
-    await remember_entity("Cloud Run", "Compute", ["Google Cloud serverless hosting."])
-
-    # Recall all
-    all_res = await recall_entities()
-    assert all_res["total_count"] == 2
-
-    # Query filter match
-    fastapi_res = await recall_entities(query="FastAPI")
-    assert fastapi_res["matches"] == 1
-    assert "FastAPI" in fastapi_res["entities"]
-
-    # Query filter non-match
-    none_res = await recall_entities(query="NonExistent")
-    assert none_res["matches"] == 0
+    # 4. Prune storage
+    prune_res = await prune_expired_memories()
+    assert prune_res["pruned_count"] == 1
+    assert "Expired Event" in prune_res["pruned_entities"]

--- a/services/gcp/mcpGateway/tests/test_radar.py
+++ b/services/gcp/mcpGateway/tests/test_radar.py
@@ -1,0 +1,50 @@
+import os
+import pytest
+from unittest.mock import patch, MagicMock
+from tools.radar import run_tech_radar
+from tools.memory import recall_entities, LOCAL_MEMORY_FILE
+
+@pytest.fixture(autouse=True)
+def cleanup_local_memory():
+    if os.path.exists(LOCAL_MEMORY_FILE):
+        os.remove(LOCAL_MEMORY_FILE)
+    yield
+    if os.path.exists(LOCAL_MEMORY_FILE):
+        os.remove(LOCAL_MEMORY_FILE)
+
+@pytest.mark.asyncio
+async def test_run_tech_radar():
+    sample_html = """
+    <html>
+      <head><title>Cloud Run Release Notes</title></head>
+      <body>
+        <h1>Cloud Run August 2026 Updates</h1>
+        <p>Added native WebSocket support for all regions.</p>
+        <p>Reduced cold start times by 30%.</p>
+      </body>
+    </html>
+    """
+    
+    mock_res = MagicMock()
+    mock_res.status_code = 200
+    mock_res.text = sample_html
+    mock_res.raise_for_status = MagicMock()
+
+    with patch("httpx.AsyncClient.get", return_value=mock_res):
+        radar_res = await run_tech_radar(
+            urls=["https://cloud.google.com/run/docs/release-notes"],
+            category="GCP Release",
+            ttl_days=60
+        )
+
+    assert radar_res["status"] == "completed"
+    assert radar_res["processed_count"] == 1
+    assert radar_res["indexed_count"] == 1
+    assert "Cloud Run Release Notes" in radar_res["indexed_entities"]
+
+    # Verify entity stored in memory
+    recalled = await recall_entities(query="Cloud Run Release Notes")
+    assert recalled["matches"] == 1
+    entity = recalled["entities"]["Cloud Run Release Notes"]
+    assert entity["category"] == "GCP Release"
+    assert entity["expires_at"] is not None

--- a/services/gcp/mcpGateway/tools/memory.py
+++ b/services/gcp/mcpGateway/tools/memory.py
@@ -1,10 +1,32 @@
 import os
+import re
 import json
+from datetime import datetime, timedelta, timezone
 from typing import Dict, Any, List, Optional
 from google.cloud import storage
 
 GCS_BUCKET_NAME = os.getenv("MEMORY_GCS_BUCKET", None)
 LOCAL_MEMORY_FILE = os.getenv("LOCAL_MEMORY_FILE", "/tmp/mcp_memory.json")
+DEFAULT_RETENTION_DAYS = int(os.getenv("MEMORY_RETENTION_DAYS", "90"))
+
+# Secret and Credential Sanitization Regexes
+SECRET_PATTERNS = [
+    (r"(sk-[a-zA-Z0-9_-]{20,})", "[REDACTED_API_KEY]"),
+    (r"(AIzaSy[a-zA-Z0-9_-]{30,})", "[REDACTED_GOOGLE_KEY]"),
+    (r"(ghp_[a-zA-Z0-9]{36})", "[REDACTED_GITHUB_TOKEN]"),
+    (r"(Bearer\s+[a-zA-Z0-9._-]{20,})", "[REDACTED_BEARER_TOKEN]"),
+    (r"(password\s*=\s*['\"][^'\"]+['\"])", "password='[REDACTED]'"),
+]
+
+def sanitize_text(text: str) -> str:
+    """Sanitizes sensitive patterns (API keys, bearer tokens, passwords) from text."""
+    if not isinstance(text, str):
+        return text
+    sanitized = text
+    for pattern, replacement in SECRET_PATTERNS:
+        sanitized = re.sub(pattern, replacement, sanitized, flags=re.IGNORECASE)
+    return sanitized
+
 
 def _load_memory() -> Dict[str, Any]:
     """Loads memory dictionary from GCS or local storage."""
@@ -26,6 +48,7 @@ def _load_memory() -> Dict[str, Any]:
             pass
 
     return {"entities": {}, "relations": []}
+
 
 def _save_memory(memory: Dict[str, Any]) -> bool:
     """Saves memory dictionary to GCS or local storage."""
@@ -50,52 +73,118 @@ def _save_memory(memory: Dict[str, Any]) -> bool:
         print(f"Error saving local memory: {e}")
         return False
 
-async def remember_entity(name: str, category: str, observations: List[str]) -> Dict[str, Any]:
+
+async def remember_entity(
+    name: str,
+    category: str,
+    observations: List[str],
+    ttl_days: Optional[int] = DEFAULT_RETENTION_DAYS,
+    pinned: bool = False
+) -> Dict[str, Any]:
     """
-    Stores an entity with observations into long-term knowledge graph memory.
+    Stores an entity with observations into long-term knowledge graph memory, applying sanitization & TTL.
     
     Args:
         name: Name of the entity (e.g., 'GCP Cloud Run', 'Krishna').
         category: Type/category (e.g., 'Infrastructure', 'Developer').
         observations: List of factual facts or notes about the entity.
+        ttl_days: Retention period in days (default 90 days). Set None for infinite.
+        pinned: If True, prevents automatic expiration pruning.
     """
     memory = _load_memory()
     entities = memory.setdefault("entities", {})
-    
-    if name not in entities:
-        entities[name] = {
-            "name": name,
-            "category": category,
-            "observations": []
+    now = datetime.now(timezone.utc)
+    now_iso = now.isoformat()
+
+    clean_name = sanitize_text(name)
+    clean_category = sanitize_text(category)
+    clean_obs = [sanitize_text(obs) for obs in observations]
+
+    expires_at = None
+    if ttl_days and not pinned:
+        expires_at = (now + timedelta(days=ttl_days)).isoformat()
+
+    if clean_name not in entities:
+        entities[clean_name] = {
+            "name": clean_name,
+            "category": clean_category,
+            "observations": [],
+            "created_at": now_iso,
+            "last_updated_at": now_iso,
+            "expires_at": expires_at,
+            "pinned": pinned
         }
-        
-    for obs in observations:
-        if obs not in entities[name]["observations"]:
-            entities[name]["observations"].append(obs)
-            
+    else:
+        entities[clean_name]["last_updated_at"] = now_iso
+        if pinned:
+            entities[clean_name]["pinned"] = True
+            entities[clean_name]["expires_at"] = None
+
+    existing_obs = entities[clean_name].setdefault("observations", [])
+    for obs in clean_obs:
+        if obs not in existing_obs:
+            existing_obs.append(obs)
+
     saved = _save_memory(memory)
     return {
         "status": "success" if saved else "warning_local_only",
-        "entity": entities[name]
+        "entity": entities[clean_name]
     }
 
-async def recall_entities(query: Optional[str] = None) -> Dict[str, Any]:
+
+async def recall_entities(query: Optional[str] = None, include_expired: bool = False) -> Dict[str, Any]:
     """
-    Recalls entities and observations stored in long-term memory.
+    Recalls unexpired entities and observations stored in long-term memory.
     
     Args:
         query: Optional search term to filter entity names or observations.
+        include_expired: If True, includes items past their expiration date.
     """
     memory = _load_memory()
     entities = memory.get("entities", {})
-    
+    now_iso = datetime.now(timezone.utc).isoformat()
+
+    valid_entities = {}
+    for name, data in entities.items():
+        expires_at = data.get("expires_at")
+        if not include_expired and expires_at and expires_at < now_iso and not data.get("pinned", False):
+            continue
+        valid_entities[name] = data
+
     if not query:
-        return {"total_count": len(entities), "entities": entities}
-        
+        return {"total_count": len(valid_entities), "entities": valid_entities}
+
     query_lower = query.lower()
     filtered = {}
-    for name, data in entities.items():
+    for name, data in valid_entities.items():
         if query_lower in name.lower() or any(query_lower in obs.lower() for obs in data.get("observations", [])):
             filtered[name] = data
-            
+
     return {"query": query, "matches": len(filtered), "entities": filtered}
+
+
+async def prune_expired_memories() -> Dict[str, Any]:
+    """Prunes expired, unpinned memories from storage based on retention policy."""
+    memory = _load_memory()
+    entities = memory.get("entities", {})
+    now_iso = datetime.now(timezone.utc).isoformat()
+
+    pruned = []
+    retained = {}
+
+    for name, data in entities.items():
+        expires_at = data.get("expires_at")
+        if expires_at and expires_at < now_iso and not data.get("pinned", False):
+            pruned.append(name)
+        else:
+            retained[name] = data
+
+    memory["entities"] = retained
+    saved = _save_memory(memory)
+
+    return {
+        "status": "success" if saved else "warning_local_only",
+        "pruned_count": len(pruned),
+        "pruned_entities": pruned,
+        "retained_count": len(retained)
+    }

--- a/services/gcp/mcpGateway/tools/radar.py
+++ b/services/gcp/mcpGateway/tools/radar.py
@@ -1,0 +1,67 @@
+import asyncio
+from typing import Dict, Any, List, Optional
+from tools.web_fetch import fetch_web_markdown
+from tools.memory import remember_entity, sanitize_text
+
+async def run_tech_radar(
+    urls: List[str],
+    category: str = "Tech Intelligence",
+    ttl_days: int = 90
+) -> Dict[str, Any]:
+    """
+    Executes a Tech Intelligence Radar pass across target URLs, indexing updates into persistent memory with retention TTL.
+    
+    Args:
+        urls: List of web URLs to monitor (e.g. release notes, product blogs, doc pages).
+        category: Memory entity category tag (default 'Tech Intelligence').
+        ttl_days: Retention period in days for intelligence entries (default 90 days).
+    """
+    results = []
+    indexed_entities = []
+
+    for url in urls:
+        fetch_res = await fetch_web_markdown(url, max_chars=4000)
+        
+        if fetch_res.get("status") == "failed" or "error" in fetch_res:
+            results.append({
+                "url": url,
+                "status": "error",
+                "error": fetch_res.get("error", "Failed to fetch URL")
+            })
+            continue
+
+        title = fetch_res.get("title", url)
+        markdown = fetch_res.get("markdown", "")
+        
+        # Extract first 5 meaningful non-header lines as key observations
+        lines = [l.strip() for l in markdown.splitlines() if l.strip() and not l.startswith("#")]
+        observations = lines[:5] if lines else ["Page content ingested and analyzed."]
+        
+        # Add source attribution
+        observations.append(f"Source URL: {url}")
+
+        # Store entity in memory with TTL retention
+        mem_res = await remember_entity(
+            name=title,
+            category=category,
+            observations=observations,
+            ttl_days=ttl_days,
+            pinned=False
+        )
+        
+        indexed_entities.append(title)
+        results.append({
+            "url": url,
+            "title": title,
+            "status": "indexed",
+            "observations_count": len(observations),
+            "retention_days": ttl_days
+        })
+
+    return {
+        "status": "completed",
+        "processed_count": len(urls),
+        "indexed_count": len(indexed_entities),
+        "indexed_entities": indexed_entities,
+        "details": results
+    }


### PR DESCRIPTION
## Summary
- Added **Tech Intelligence Radar** tool (`run_tech_radar`) to monitor web URLs (release notes, docs), parse updates, and ingest intelligence facts into memory.
- Implemented **Memory Retention Policy (TTL)** with configurable retention days (default 90 days), timestamps (`created_at`, `last_updated_at`, `expires_at`), pinned entity support, and memory pruning (`prune_memory`).
- Implemented **Automated Secret & Credential Sanitization** (`sanitize_text`) to automatically redact API keys (`sk-...`, `AIza...`), Bearer tokens, and passwords.
- Added comprehensive unit test coverage in `tests/test_radar.py` and updated `tests/test_memory.py`.
- Re-deployed live to GCP Cloud Run: `https://mcp-gateway-boq6jlznga-uc.a.run.app`