### PR TITLE
feat(gcp): add GCP Secret Manager dynamic email whitelisting and 403 Forbidden authorization guard

### DIFF
--- a/services/gcp/mcpGateway/auth.py
+++ b/services/gcp/mcpGateway/auth.py
@@ -1,5 +1,5 @@
 import os
-from typing import Optional, Dict, Any
+from typing import Optional, Dict, Any, List
 from fastapi import Request, HTTPException, Security, status
 from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
 from google.oauth2 import id_token
@@ -9,13 +9,38 @@ security = HTTPBearer(auto_error=False)
 
 DISABLE_AUTH = os.getenv("DISABLE_AUTH", "false").lower() in ("true", "1", "yes")
 GOOGLE_CLIENT_ID = os.getenv("GOOGLE_CLIENT_ID", None)
+GCP_PROJECT_ID = os.getenv("GCP_PROJECT", os.getenv("GOOGLE_CLOUD_PROJECT", "precise-works-456015-h9"))
+SECRET_NAME = os.getenv("SECRET_NAME", "mcp-gateway-allowed-emails")
+DEFAULT_ALLOWED_EMAIL = os.getenv("ALLOWED_EMAILS", "krishna.kasinadhuni@gmail.com")
+
+def _get_allowed_emails() -> List[str]:
+    """
+    Dynamically fetches allowed user emails from GCP Secret Manager or environment config.
+    Returns a lowercased list of authorized emails.
+    """
+    # 1. Try reading secret from GCP Secret Manager
+    try:
+        from google.cloud import secretmanager
+        client = secretmanager.SecretManagerServiceClient()
+        secret_path = f"projects/{GCP_PROJECT_ID}/secrets/{SECRET_NAME}/versions/latest"
+        response = client.access_secret_version(request={"name": secret_path})
+        secret_value = response.payload.data.decode("UTF-8").strip()
+        if secret_value:
+            return [e.strip().lower() for e in secret_value.split(",") if e.strip()]
+    except Exception:
+        pass
+
+    # 2. Fallback to ALLOWED_EMAILS environment variable or default
+    return [e.strip().lower() for e in DEFAULT_ALLOWED_EMAIL.split(",") if e.strip()]
+
 
 async def verify_oauth_token(
     request: Request,
     credentials: Optional[HTTPAuthorizationCredentials] = Security(security)
 ) -> Dict[str, Any]:
     """
-    Verifies Google OAuth 2.0 / OIDC ID Token from Bearer header or 'token' query param.
+    Verifies Google OAuth 2.0 / OIDC ID Token from Bearer header or 'token' query param,
+    and enforces dynamic GCP Secret Manager email whitelisting.
     """
     if DISABLE_AUTH:
         return {"email": "dev-user@example.com", "sub": "dev-user-id", "name": "Local Dev User"}
@@ -52,7 +77,19 @@ async def verify_oauth_token(
                 detail="Invalid token issuer.",
             )
 
+        # Enforce Email Whitelist (GCP Secret Manager / Environment)
+        user_email = id_info.get("email", "").lower()
+        allowed_emails = _get_allowed_emails()
+
+        if allowed_emails and user_email not in allowed_emails:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail=f"Access denied. '{user_email}' is not authorized to access this MCP Gateway."
+            )
+
         return id_info
+    except HTTPException:
+        raise
     except ValueError as e:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,

--- a/services/gcp/mcpGateway/requirements.txt
+++ b/services/gcp/mcpGateway/requirements.txt
@@ -5,6 +5,7 @@ python-dotenv>=1.0.0
 httpx>=0.26.0
 beautifulsoup4>=4.12.0
 google-cloud-storage>=2.14.0
+google-cloud-secret-manager>=2.18.0
 pydantic>=2.6.0
 requests>=2.31.0
 pytest>=7.4.0

--- a/services/gcp/mcpGateway/tests/test_gateway_api.py
+++ b/services/gcp/mcpGateway/tests/test_gateway_api.py
@@ -1,6 +1,6 @@
 import os
 import pytest
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
 from fastapi.testclient import TestClient
 from main import app
 
@@ -30,6 +30,38 @@ def test_auth_verify_disabled_auth():
         assert data["user"]["email"] == "dev-user@example.com"
 
 
+def test_auth_verify_email_whitelisted():
+    mock_id_info = {
+        "iss": "https://accounts.google.com",
+        "email": "krishna.kasinadhuni@gmail.com",
+        "sub": "user-123"
+    }
+    with patch("auth.DISABLE_AUTH", False), \
+         patch("google.oauth2.id_token.verify_oauth2_token", return_value=mock_id_info):
+        response = client.get(
+            "/api/auth/verify",
+            headers={"Authorization": "Bearer fake-valid-token"}
+        )
+        assert response.status_code == 200
+        assert response.json()["user"]["email"] == "krishna.kasinadhuni@gmail.com"
+
+
+def test_auth_verify_email_forbidden():
+    mock_id_info = {
+        "iss": "https://accounts.google.com",
+        "email": "unauthorized-hacker@example.com",
+        "sub": "user-456"
+    }
+    with patch("auth.DISABLE_AUTH", False), \
+         patch("google.oauth2.id_token.verify_oauth2_token", return_value=mock_id_info):
+        response = client.get(
+            "/api/auth/verify",
+            headers={"Authorization": "Bearer fake-unauthorized-token"}
+        )
+        assert response.status_code == 403
+        assert "Access denied" in response.json()["detail"]
+
+
 def test_list_tools_api():
     with patch("auth.DISABLE_AUTH", True):
         response = client.get("/api/tools")
@@ -39,6 +71,8 @@ def test_list_tools_api():
         assert "fetch_web_page" in tool_names
         assert "store_memory" in tool_names
         assert "query_memory" in tool_names
+        assert "run_tech_radar" in tool_names
+        assert "prune_memory" in tool_names
 
 
 def test_call_tool_api_store_and_query():
@@ -73,7 +107,6 @@ def test_call_tool_api_store_and_query():
 
 
 def test_mcp_jsonrpc_initialize():
-    # Setup session
     from main import sse_sessions
     import asyncio
     
@@ -94,7 +127,6 @@ def test_mcp_jsonrpc_initialize():
         assert response.status_code == 200
         assert response.json()["status"] == "accepted"
         
-        # Check queued response
         res_msg = queue.get_nowait()
         assert res_msg["id"] == 1
         assert res_msg["result"]["protocolVersion"] == "2024-11-05"


### PR DESCRIPTION
## Summary
- Integrated **GCP Secret Manager** (`google-cloud-secret-manager`) to dynamically manage authorized email whitelists (`mcp-gateway-allowed-emails`).
- Added `403 Forbidden` authorization guard in `auth.py` (`_get_allowed_emails()`).
- Prevents unauthorized Google Account tokens from accessing hosted MCP tools and knowledge graph memory.
- Default whitelisted email configured for `krishna.kasinadhuni@gmail.com`.
- Added unit test cases for `403 Forbidden` and `200 OK` in `tests/test_gateway_api.py`.
- Re-deployed live to GCP Cloud Run: `https://mcp-gateway-boq6jlznga-uc.a.run.app`